### PR TITLE
Use namespaces

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -17,15 +17,30 @@ import sys
 from rclpy.constants import S_TO_NS
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import Node
+from rclpy.validate_namespace import validate_namespace
+from rclpy.validate_node_name import validate_node_name
 
 
 def init(*, args=None):
-    # Now we can use _rclpy to call the implementation specific rclpy_init().
     return _rclpy.rclpy_init(args if args is not None else sys.argv)
 
 
 def create_node(node_name, *, namespace=None):
-    node_handle = _rclpy.rclpy_create_node(node_name, namespace or '')
+    namespace = namespace or ''
+    failed = False
+    try:
+        node_handle = _rclpy.rclpy_create_node(node_name, namespace)
+    except ValueError:
+        failed = True
+    if failed:
+        # these will raise more specific errors if the name or namespace is bad
+        validate_node_name(node_name)
+        # emulate what rcl_node_init() does to accept '' and relative namespaces
+        if not namespace:
+            namespace = '/'
+        if not namespace.startswith('/'):
+            namespace = '/' + namespace
+        validate_namespace(namespace)
     return Node(node_handle)
 
 

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -20,15 +20,48 @@ class NotInitializedException(Exception):
         Exception.__init__(self, 'rclpy.init() has not been called', *args)
 
 
-class NoImplementationAvailableException(Exception):
-    """Raised when there is no rmw implementation with a Python extension available."""
-
-    def __init__(self, *args):
-        Exception.__init__(self, 'no rmw implementation with a Python extension available')
-
-
 class NoTypeSupportImportedException(Exception):
     """Raised when there is no type support imported."""
 
     def __init__(self, *args):
         Exception.__init__(self, 'no type_support imported')
+
+
+class NameValidationException(Exception):
+    """Raised when a topic name, node name, or namespace are invalid."""
+
+    def __init__(self, name_type, name, error_msg, invalid_index, *args):
+        msg = """\
+Invalid {name_type}: {error_msg}:
+  '{name}'
+   {indent}^\
+""".format(name_type=name_type, name=name, error_msg=error_msg, indent=' ' * invalid_index)
+        Exception.__init__(self, msg)
+
+
+class InvalidNamespaceException(NameValidationException):
+    """Raised when a namespace is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "namespace", name, error_msg, invalid_index)
+
+
+class InvalidNodeNameException(NameValidationException):
+    """Raised when a node name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "node name", name, error_msg, invalid_index)
+
+
+class InvalidTopicNameException(NameValidationException):
+    """Raised when a topic name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "topic name", name, error_msg, invalid_index)
+
+
+class InvalidServiceNameException(NameValidationException):
+    """Raised when a service name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "service name", name, error_msg, invalid_index)

--- a/rclpy/rclpy/expand_topic_name.py
+++ b/rclpy/rclpy/expand_topic_name.py
@@ -1,0 +1,33 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def expand_topic_name(topic_name, node_name, node_namespace):
+    """
+    Expand a given topic name using given node name and namespace as well.
+
+    Note that this function can succeed but the expanded topic name may still
+    be invalid.
+    The :py:func:validate_full_topic_name(): should be used on the expanded
+    topic name to ensure it is valid after expansion.
+
+    :param topic_name str: topic name to be expanded
+    :param node_name str: name of the node that this topic is associated with
+    :param namespace str: namespace that the topic is within
+    :returns: expanded topic name which is fully qualified
+    :raises: ValueError if the topic name, node name or namespace are invalid
+    """
+    return _rclpy.rclpy_expand_topic_name(topic_name, node_name, node_namespace)

--- a/rclpy/rclpy/validate_full_topic_name.py
+++ b/rclpy/rclpy/validate_full_topic_name.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_full_topic_name(name, *, is_service=False):
+    """
+    Validate a given topic or service name, and raise an exception if invalid.
+
+    The name must be fully-qualified and already expanded.
+
+    If the name is invalid then rclpy.exceptions.InvalidTopicNameException
+    will be raised.
+
+    :param name str: topic or service name to be validated
+    :param is_service bool: if true, InvalidServiceNameException is raised
+    :returns: True when it is valid
+    :raises: InvalidTopicNameException: when the name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_full_topic_name(name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    if is_service:
+        raise InvalidServiceNameException(name, error_msg, invalid_index)
+    else:
+        raise InvalidTopicNameException(name, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_namespace.py
+++ b/rclpy/rclpy/validate_namespace.py
@@ -1,0 +1,38 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidNamespaceException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_namespace(namespace):
+    """
+    Validate a given namespace, and raise an exception if it is invalid.
+
+    Unlike the node constructor, which allows namespaces without a leading '/'
+    and empty namespaces "", this function requires that the namespace be
+    absolute and non-empty.
+
+    If the namespace is invalid then rclpy.exceptions.InvalidNamespaceException
+    will be raised.
+
+    :param namespace str: namespace to be validated
+    :returns: True when it is valid
+    :raises: InvalidNamespaceException: when the namespace is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_namespace(namespace)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    raise InvalidNamespaceException(namespace, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_node_name.py
+++ b/rclpy/rclpy/validate_node_name.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidNodeNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_node_name(node_name):
+    """
+    Validate a given node_name, and raise an exception if it is invalid.
+
+    If the node_name is invalid then rclpy.exceptions.InvalidNodeNameException
+    will be raised.
+
+    :param node_name str: node_name to be validated
+    :returns: True when it is valid
+    :raises: InvalidNodeNameException: when the node_name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_node_name(node_name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    raise InvalidNodeNameException(node_name, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_topic_name.py
+++ b/rclpy/rclpy/validate_topic_name.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_topic_name(name, *, is_service=False):
+    """
+    Validate a given topic or service name, and raise an exception if invalid.
+
+    The name does not have to be fully-qualified and is not expanded.
+
+    If the name is invalid then rclpy.exceptions.InvalidTopicNameException
+    will be raised.
+
+    :param name str: topic or service name to be validated
+    :param is_service bool: if true, InvalidServiceNameException is raised
+    :returns: True when it is valid
+    :raises: InvalidTopicNameException: when the name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_topic_name(name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    if is_service:
+        raise InvalidServiceNameException(name, error_msg, invalid_index)
+    else:
+        raise InvalidTopicNameException(name, error_msg, invalid_index)

--- a/rclpy/test/test_expand_topic_name.py
+++ b/rclpy/test/test_expand_topic_name.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.expand_topic_name import expand_topic_name
+
+
+class TestExpandTopicName(unittest.TestCase):
+
+    def test_expand_topic_name(self):
+        tests = {
+            # 'expected output': ['input topic', 'node', '/ns']
+            '/ns/chatter': ['chatter', 'node_name', '/ns'],
+            '/chatter': ['chatter', 'node_name', '/'],
+            '/ns/node_name/chatter': ['~/chatter', 'node_name', '/ns'],
+            '/node_name/chatter': ['~/chatter', 'node_name', '/'],
+        }
+        for expected_topic, input_tuple in tests.items():
+            topic, node, namespace = input_tuple
+            expanded_topic = expand_topic_name(topic, node, namespace)
+            self.assertEqual(expanded_topic, expected_topic)
+
+    def test_expand_topic_name_invalid_node_name(self):
+        # node name may not contain '?'
+        with self.assertRaisesRegex(ValueError, 'node name'):
+            expand_topic_name('topic', 'invalid_node_name?', '/ns')
+
+    def test_expand_topic_name_invalid_namespace_empty(self):
+        # namespace may not be empty
+        with self.assertRaisesRegex(ValueError, 'namespace'):
+            expand_topic_name('topic', 'node_name', '')
+
+    def test_expand_topic_name_invalid_namespace_relative(self):
+        # namespace may not be relative
+        with self.assertRaisesRegex(ValueError, 'namespace'):
+            expand_topic_name('topic', 'node_name', 'ns')
+
+    def test_expand_topic_name_invalid_topic(self):
+        # topic may not contain '?'
+        with self.assertRaisesRegex(ValueError, 'topic name'):
+            expand_topic_name('invalid/topic?', 'node_name', '/ns')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1,0 +1,81 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rcl_interfaces.srv import GetParameters
+import rclpy
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from std_msgs.msg import String
+
+
+class TestNode(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('my_node', namespace='/my_ns')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_accessors(self):
+        self.assertIsNotNone(self.node.handle)
+        with self.assertRaises(AttributeError):
+            self.node.handle = 'garbage'
+        self.assertEqual(self.node.get_name(), 'my_node')
+        self.assertEqual(self.node.get_namespace(), '/my_ns')
+
+    def test_create_publisher(self):
+        self.node.create_publisher(String, 'chatter')
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            self.node.create_publisher(String, 'chatter?')
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            self.node.create_publisher(String, '/chatter/42_is_the_answer')
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_publisher(String, 'chatter/{bad_sub}')
+
+    def test_create_subscription(self):
+        self.node.create_subscription(String, 'chatter', lambda msg: print(msg))
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            self.node.create_subscription(String, 'chatter?', lambda msg: print(msg))
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            self.node.create_subscription(String, '/chatter/42ish', lambda msg: print(msg))
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_subscription(String, 'foo/{bad_sub}', lambda msg: print(msg))
+
+    def test_create_client(self):
+        self.node.create_client(GetParameters, 'get/parameters')
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            self.node.create_client(GetParameters, 'get/parameters?')
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            self.node.create_client(GetParameters, '/get/42parameters')
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_client(GetParameters, 'foo/{bad_sub}')
+
+    def test_create_service(self):
+        self.node.create_service(GetParameters, 'get/parameters', lambda req: None)
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            self.node.create_service(GetParameters, 'get/parameters?', lambda req: None)
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            self.node.create_service(GetParameters, '/get/42parameters', lambda req: None)
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_service(GetParameters, 'foo/{bad_sub}', lambda req: None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_full_topic_name.py
+++ b/rclpy/test/test_validate_full_topic_name.py
@@ -1,0 +1,52 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.validate_full_topic_name import validate_full_topic_name
+
+
+class TestValidateFullTopicName(unittest.TestCase):
+
+    def test_validate_full_topic_name(self):
+        tests = [
+            '/chatter',
+            '/node_name/chatter',
+            '/ns/node_name/chatter',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_full_topic_name(topic)
+
+    def test_validate_full_topic_name_failures(self):
+        # topic name may not contain '?'
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            validate_full_topic_name('/invalid_topic?')
+        # topic name must start with /
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must be absolute'):
+            validate_full_topic_name('invalid_topic')
+
+    def test_validate_full_topic_name_failures_services(self):
+        # service name may not contain '?'
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            validate_full_topic_name('/invalid_service?', is_service=True)
+        # service name must start with /
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must be absolute'):
+            validate_full_topic_name('invalid_service', is_service=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_namespace.py
+++ b/rclpy/test/test_validate_namespace.py
@@ -1,0 +1,42 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidNamespaceException
+from rclpy.validate_namespace import validate_namespace
+
+
+class TestValidateNamespace(unittest.TestCase):
+
+    def test_validate_namespace(self):
+        tests = [
+            '/my_ns',
+            '/',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_namespace(topic)
+
+    def test_validate_namespace_failures(self):
+        # namespace must not be empty
+        with self.assertRaisesRegex(InvalidNamespaceException, 'empty'):
+            validate_namespace('')
+        # namespace must start with /
+        with self.assertRaisesRegex(InvalidNamespaceException, 'must be absolute'):
+            validate_namespace('invalid_namespace')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_node_name.py
+++ b/rclpy/test/test_validate_node_name.py
@@ -1,0 +1,44 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidNodeNameException
+from rclpy.validate_node_name import validate_node_name
+
+
+class TestValidateNodeName(unittest.TestCase):
+
+    def test_validate_node_name(self):
+        tests = [
+            'my_node',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_node_name(topic)
+
+    def test_validate_node_name_failures(self):
+        # node name must not be empty
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not be empty'):
+            validate_node_name('')
+        # node name may not contain '?'
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
+            validate_node_name('invalid_node?')
+        # node name must not contain /
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
+            validate_node_name('/invalid_node')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_topic_name.py
+++ b/rclpy/test/test_validate_topic_name.py
@@ -1,0 +1,52 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.validate_topic_name import validate_topic_name
+
+
+class TestValidateTopicName(unittest.TestCase):
+
+    def test_validate_topic_name(self):
+        tests = [
+            'chatter',
+            '{node}/chatter',
+            '~/chatter',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_topic_name(topic)
+
+    def test_validate_topic_name_failures(self):
+        # topic name may not contain '?'
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            validate_topic_name('/invalid_topic?')
+        # topic name must start with number in any token
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            validate_topic_name('invalid/42topic')
+
+    def test_validate_topic_name_failures_service(self):
+        # service name may not contain '?'
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            validate_topic_name('/invalid_service?', is_service=True)
+        # service name must start with number in any token
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            validate_topic_name('invalid/42service', is_service=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Recreated from original PR: https://github.com/ros2/rclpy/pull/86

Connects to ros2/rcl#137

Here are some examples of what it looks like when you give invalid names now:

- invalid node name

```
% python3 -c "import rclpy; rclpy.init(); rclpy.create_node('invalid_node?')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/__init__.py", line 38, in create_node
    validate_node_name(node_name)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-pac...